### PR TITLE
Update API Heading to Sign-Statement

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -345,7 +345,7 @@ TODO: other error codes
 
 The following HTTP endpoints are optional to implement.
 
-### Issue Statement
+### Issue Signed Statement
 
 Authentication MUST be implemented for this endpoint.
 


### PR DESCRIPTION
The current heading says: "Issue Statement", which would refer to a document the issuer is looking to create/issue. This is simply a heading change to reflect the service will Sign the Statement on their behalf, differentiating the statement as a payload. 

The heading and even the API name are another discussion as the doc, as written, isn't clear if it simply returns a signed statement, the client must re-submit under `/entries`, or the `signed-statement/issue` would also register. Based on that discussion, we may want to also rename the API.

- It's clear why the API would return the signed statement, for the client to hold and attach to a receipt. 
- It's not clear why a user would need to re-submit a signed statement, requiring multiple round trips (see #10)