### PR TITLE
Remove redundant response code

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -122,8 +122,6 @@ If the Transparency Service cannot process a client's request, it MUST return an
 - instance: A URN reference identifying the problem.
 To facilitate automated response to errors, this document defines a set of standard tokens for use in the type field within the URN namespace of: "urn:ietf:params:scitt:error:".
 
-- response-code: The HTTP error response code relating to this error.
-
 TODO: RESOLVE this dangling media-type
 
 application/concise-problem-details+cbor
@@ -142,8 +140,7 @@ Examples of errors may include:
   / detail /        -2: \
             "Signing algorithm 'WalnutDSA' not supported",
   / instance /      -3: \
-            "urn:ietf:params:scitt:error:badSignatureAlgorithm",
-  / response-code / -4: 400,
+            "urn:ietf:params:scitt:error:badSignatureAlgorithm"
 }
 ~~~
 
@@ -329,8 +326,7 @@ application/concise-problem-details+cbor
   / detail /        -2: \
           "Signed Statement contained a non supported algorithm",
   / instance /      -3: \
-          "urn:ietf:params:scitt:error:badSignatureAlgorithm",
-  / response-code / -4: 400,
+          "urn:ietf:params:scitt:error:badSignatureAlgorithm"
 }
 ~~~
 
@@ -345,8 +341,7 @@ application/concise-problem-details+cbor
           "Signed Statement did not contain proof of possession",
   / instance /      -3: \
           "urn:ietf:params:scitt:error:signed-statement:\
-          confirmation-missing",
-  / response-code / -4: 400,
+          confirmation-missing"
 }
 ~~~
 
@@ -362,8 +357,7 @@ application/concise-problem-details+cbor
           (must be present)",
   / instance /      -3: \
           "urn:ietf:params:scitt:error:signed-statement:\
-          payload-missing",
-  / response-code / -4: 400,
+          payload-missing"
 }
 ~~~
 
@@ -379,8 +373,7 @@ application/concise-problem-details+cbor
           (must not be present)",
   / instance /      -3: \
           "urn:ietf:params:scitt:error:signed-statement:\
-          payload-forbidden",
-  / response-code / -4: 400,
+          payload-forbidden"
 }
 ~~~
 
@@ -396,8 +389,7 @@ application/concise-problem-details+cbor
           Registration Policy",
   / instance /      -3: \
           "urn:ietf:params:scitt:error:signed-statement:\
-          rejected-by-registration-policy",
-  / response-code / -4: 400,
+          rejected-by-registration-policy"
 }
 ~~~
 
@@ -490,8 +482,7 @@ application/concise-problem-details+cbor
 {
   / title /         -1: "Invalid locator",
   / detail /        -2: "Operation locator is not in a valid form",
-  / instance /      -3: "urn:ietf:params:scitt:error:invalidRequest",
-  / response-code / -4: 400,
+  / instance /      -3: "urn:ietf:params:scitt:error:invalidRequest"
 }
 ~~~
 
@@ -509,8 +500,7 @@ application/concise-problem-details+cbor
   / detail /        -2: \
           "No running operation was found matching the requested ID",
   / instance /      -3: \
-          "urn:ietf:params:scitt:error:notFound",
-  / response-code / -4: 404,
+          "urn:ietf:params:scitt:error:notFound"
 }
 ~~~
 
@@ -529,8 +519,7 @@ Retry-After: <seconds>
   / detail /        -2: \
           "Only <number> requests per <period> are allowed.",
   / instance /      -3: \
-          "urn:ietf:params:scitt:error:tooManyRequests",
-  / response-code / -4: 429,
+          "urn:ietf:params:scitt:error:tooManyRequests"
 }
 ~~~
 
@@ -582,8 +571,7 @@ application/concise-problem-details+cbor
           "Receipt with entry ID <id> not known \
           to this Transparency Service",
   / instance /      -3: \
-          "urn:ietf:params:scitt:error:receipt:not-found",
-  / response-code / -4: 404,
+          "urn:ietf:params:scitt:error:receipt:not-found"
 }
 ~~~
 
@@ -638,8 +626,7 @@ application/concise-problem-details+cbor
   / detail /        -2: \
           "No Signed Statement found with the specified ID",
   / instance /      -3: \
-          "urn:ietf:params:scitt:error:notFound",
-  / response-code / -4: 404,
+          "urn:ietf:params:scitt:error:notFound"
 ~~~
 
 #### Eventual Consistency


### PR DESCRIPTION
`response-code` exists in RFC9290 for CoAP-specific purposes that do not apply here. Accordingly, it is [optional](https://www.rfc-editor.org/rfc/rfc9290.html#name-basic-problem-details). In SCITT, it adds no value that the HTTP return code does not provide, and creates difficulty for clients who need to decide what to do if the values differ.