### PR TITLE
Proposal: simplify asynchronous submission flow

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -307,6 +307,31 @@ Retry-After: <seconds>
 
 The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
 
+#### Status 200 - Asynchronous registration is successful
+
+Along with the receipt the Transparency Service MAY return a locator in the HTTP response `Location` header, provided the locator is a valid URL.
+
+~~~ http-message
+HTTP/1.1 200 OK
+
+Location: https://transparency.example/entries\
+/67ed41f1de6a...cfc158694ed0befe
+
+Content-Type: application/cose
+
+Payload (in CBOR diagnostic notation)
+
+18([                            / COSE Sign1         /
+  h'a1013822',                  / Protected Header   /
+  {},                           / Unprotected Header /
+  null,                         / Detached Payload   /
+  h'269cd68f4211dffc...0dcb29c' / Signature          /
+])
+~~~
+
+The response contains the Receipt for the Signed Statement.
+Fresh Receipts may be requested through the resource identified in the Location header.
+
 #### Status 400 - Invalid Client Request
 
 The following expected errors are defined.

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -275,7 +275,7 @@ The Transparency Service MAY include a `Retry-After` header in the HTTP response
 
 ### Query Registration Status
 
-This endpoint lets a client query a Transparency Service for the registration status of a payload they have submitted earlier, and for which they have received a 303 - Registration is running response.
+This endpoint lets a client query a Transparency Service for the registration status of a payload they have submitted earlier, and for which they have received a 303 or 302 - Registration is running response.
 
 Request:
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -231,7 +231,7 @@ One of the following:
 
 #### Status 201 - Registration is successful
 
-If the Transparency Service is able to mint receipts within a reasonable time, it may return the receipt directly.
+If the Transparency Service is able to produce a Receipt within a reasonable time, it MAY return it directly.
 
 Along with the receipt the Transparency Service MAY return a locator in the HTTP response `Location` header, provided the locator is a valid URL.
 
@@ -258,7 +258,7 @@ Fresh Receipts may be requested through the resource identified in the Location 
 
 #### Status 303 - Registration is running
 
-In cases where the registration request is accepted but the Transparency Service is not able to mint Receipts in a reasonable time, it returns a locator for the registration operation, as in this non-normative example:
+In cases where the registration request is accepted but the Transparency Service is not able to produce a Receipt in a reasonable time, it MAY return a locator for the registration operation, as in this non-normative example:
 
 ~~~ http
 HTTP/1.1 303 See Other
@@ -268,6 +268,26 @@ Content-Type: application/cose
 Content-Length: 0
 Retry-After: <seconds>
 ~~~
+
+The location MAY be temporary, and the service may not serve a relevant response at this Location after a reasonable delay.
+
+### Query Registration Status
+
+This endpoint lets a client query a Transparency Service for the registration status of a payload they have submitted earlier, and for which they have received a 303 - Registration is running response.
+
+Request:
+
+~~~http
+GET /entries/67ed...befe HTTP/1.1
+Host: transparency.example
+Accept: application/cbor
+Accept: application/cose
+Content-Type: application/cose
+~~~
+
+Response:
+
+One of the following:
 
 #### Status 302 - Registration is running
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -271,6 +271,8 @@ Retry-After: <seconds>
 
 The location MAY be temporary, and the service may not serve a relevant response at this Location after a reasonable delay.
 
+The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
+
 ### Query Registration Status
 
 This endpoint lets a client query a Transparency Service for the registration status of a payload they have submitted earlier, and for which they have received a 303 - Registration is running response.
@@ -292,7 +294,6 @@ One of the following:
 #### Status 302 - Registration is running
 
 Registration requests MAY fail, in which case the Location MAY return an error when queried.
-The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
 
 If the client requests (GET) the location when the registration is still in progress, the TS MAY return a 302 Found, as in this non-normative example:
 
@@ -304,6 +305,9 @@ Content-Type: application/cose
 Content-Length: 0
 Retry-After: <seconds>
 ~~~
+
+
+The location MAY be temporary, and the service may not serve a relevant response at this Location after a reasonable delay.
 
 The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -284,7 +284,8 @@ Retry-After: <seconds>
 
 #### Status 302 - Registration is running
 
-Registration requests MAY fail, in which case the Location MAY return an error when queried. The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
+Registration requests MAY fail, in which case the Location MAY return an error when queried.
+The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
 
 If the client requests (GET) the location when the registration is still in progress, the TS MAY return a 302 Found, as in this non-normative example:
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -306,7 +306,6 @@ Content-Length: 0
 Retry-After: <seconds>
 ~~~
 
-
 The location MAY be temporary, and the service may not serve a relevant response at this Location after a reasonable delay.
 
 The Transparency Service MAY include a `Retry-After` header in the HTTP response to help with polling.
@@ -335,6 +334,27 @@ Payload (in CBOR diagnostic notation)
 
 The response contains the Receipt for the Signed Statement.
 Fresh Receipts may be requested through the resource identified in the Location header.
+
+As an example, a successful asynchronous follows the following sequence:
+
+~~~
+Initial exchange:
+
+Client --- POST /entries (Signed Statement) --> TS
+Client <-- 303 Location: .../entries/tmp123 --- TS
+
+May happen zero or more times:
+
+Client --- GET .../entries/tmp123           --> TS
+Client <-- 302 Location: .../entries/tmp123 --- TS
+
+Finally:
+
+Client --- GET .../entries/tmp123           --> TS
+Client <-- 200 (Transparent Statement)      --- TS
+           Location: .../entries/final123
+~~~
+
 
 #### Status 400 - Invalid Client Request
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -102,7 +102,7 @@ In addition to these operational HTTP endpoints, this specification defines supp
 
 {::boilerplate bcp14-tagged}
 
-This specification uses the terms "Signed Statement", "Receipt", "Transparent Statement", "Artifact Repositories", "Transparency Service", "Append-Only Log" and "Registration Policy" as defined in {{-SCITT-ARCH}}.
+This specification uses the terms "Signed Statement", "Receipt", "Transparent Statement", "Artifact Repositories", "Transparency Service" and "Registration Policy" as defined in {{-SCITT-ARCH}}.
 
 This specification uses "payload" as defined in {{RFC9052}}.
 


### PR DESCRIPTION
I think we can simplify the asynchronous submission flow substantially by:

1. Using appropriate HTTP return codes
2. Using Location

As far as I can tell, [303 is intended for that purpose](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303).

# Proposed flow

All line numbers are post-diff:

```mermaid
sequenceDiagram
    Client->>+TS: POST Signed Statement /entries (:207)
    TS->>-Client: 303 Location: /entry/(final or temp)-1234 (:259)
    loop 
    Client->>+TS: GET /entry/final-1234 (:549)
    TS->>-Client: 302 Location: /entry/(final or temp)-1234 (:292)
    end
    Client->>+TS: GET /entry/(final or temp)-1234 (:549)
    TS->>-Client: 200 Location: /entry/final-1234 (Missing, we only have 201)
```

This allows:

1. Delayed decision about the result and location
2. As few as 2 requests when the service is quick

# FAQ

## Why [303 - See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) at first?

Because it allows the `POST` -> `GET` switch.

> The HTTP 303 See Other [redirection response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) status code indicates that the browser should redirect to the URL in the [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) header instead of rendering the requested resource.

> This response code is often sent back as a result of [PUT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT) or [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) methods so the client may retrieve a confirmation, or view a representation of a real-world object (see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14)). The method to retrieve the redirected resource is always [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET).

## Why [302 Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) next?

> The HTTP 302 Found [redirection response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) status code indicates that the requested resource has been temporarily moved to the URL in the [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) header.

## Is it ok to set a Retry-After on a 302?

[Yes](https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after)

## Would [307](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) also work here? 

Yes.

> 307 and 302 responses are identical when the request method is [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET).

## It is worth using 308 when the permanent location is decided, rather than stay with 302 the whole time?

I don't think so, that seems like an unnecessary complication. 302 does not mandate that the Location must change.

On failure:

```mermaid
sequenceDiagram
    Client->>+TS: POST Signed Statement /entries (:207)
    TS->>-Client: 303 Location: /entry/(final or temp)-1234 (:259)
    loop 
    Client->>+TS: GET /entry/final-1234 (:549)
    TS->>-Client: 302 Location: /entry/(final or temp)-1234 (:292)
    end
    Client->>+TS: GET /entry/(final or temp)-1234 (:549)
    TS->>-Client: 400 Registration Failure (CBOR body with details) (Various locations)
```