### PR TITLE
Update transparency-config with current sample produced by scitt-ccf-ledger implementation

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -190,7 +190,7 @@ Payload (in CBOR diagnostic notation)
 
 {
   "issuer": "https://transparency.example",
-  "jwksUri": "https://transparency.example/jwks"
+  "jwks_uri": "https://transparency.example/jwks"
 }
 ~~~
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -189,7 +189,7 @@ Content-Type: application/cbor
 Payload (in CBOR diagnostic notation)
 
 {
-  "issuer": "transparency.example",
+  "issuer": "https://transparency.example",
   "jwksUri": "https://transparency.example/jwks"
 }
 ~~~

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -177,29 +177,21 @@ Request:
 ~~~ http-message
 GET /.well-known/transparency-configuration HTTP/1.1
 Host: transparency.example
-Accept: application/cose
+Accept: application/cbor
 ~~~
 
 Response:
 
 ~~~ http-message
 HTTP/1.1 200 Ok
-Content-Type: application/cose
+Content-Type: application/cbor
 
 Payload (in CBOR diagnostic notation)
 
-18([                   ; COSE_Sign1 structure with tag 18
-    h'44A123BEEFFACE', ; Protected header (example bytes)
-    {},                ; Unprotected header
-    {                  ; Payload - CBOR map
-        "issuer": "https://transparency.example",
-        "base_url": "https://transparency.example/v1/scrapi",
-        "oidc_auth_endpoint": "https://transparency.example/auth",
-        "registration_policy": "https://transparency.example/statements/\
-urn:ietf:params:scitt:statement:sha-256:base64url:5i6UeRzg1...qnGmr1o"
-    },
-    h'ABCDEF1234567890ABCDEF1234567890'  ; Signature
-])
+{
+  "issuer": "transparency.example",
+  "jwksUri": "https://transparency.example/jwks"
+}
 ~~~
 
 Responses to this message are vendor-specific.


### PR DESCRIPTION
Closes #61, @robinbryce can we get a sample from the datatrails implementation as well?