### PR TITLE
Propose Receipt Exchange Endpoint

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -575,7 +575,7 @@ Payload (in CBOR diagnostic notation)
   / protected   / <<{
     / key / 4 : "0vx7agoebGc...9nndrQmbX",
     / algorithm / 1 : -35,  # ES384
-    / vds           / 395 : 1, # RFC9162 SHA-256
+    / vds       / 395 : 1, # RFC9162 SHA-256
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -573,7 +573,7 @@ Payload (in CBOR diagnostic notation)
 
 / cose-sign1 / 18([
   / protected   / <<{
-    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / key / 4 : "0vx7agoebGc...9nndrQmbX",
     / algorithm / 1 : -7,  # ES256
     / vds           / 395 : 1, # RFC9162 SHA-256
     / claims / 15 : {

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -537,7 +537,7 @@ Payload (in CBOR diagnostic notation)
   / protected   / <<{
     / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
     / algorithm / 1 : -7,  # ES256
-    / vds           / 395 : 1, # RFC9162 SHA-256
+    / vds        / 395 : 1, # RFC9162 SHA-256
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -520,6 +520,8 @@ application/concise-problem-details+cbor
 }
 ~~~
 
+## Optional Endpoints
+
 ### Exchange Receipt
 
 Authentication SHOULD be implemented for this endpoint.

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -541,6 +541,7 @@ Payload (in CBOR diagnostic notation)
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",
+      / iat / 6: 1443944944
     },
   }>>,
   / unprotected / {

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -578,7 +578,7 @@ Payload (in CBOR diagnostic notation)
   / protected   / <<{
     / key / 4 : "0vx7agoebGc...9nndrQmbX",
     / algorithm / 1 : -35,  # ES384
-    / vds       / 395 : 1, # RFC9162 SHA-256
+    / vds       / 395 : 1,  # RFC9162 SHA-256
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -601,7 +601,6 @@ Payload (in CBOR diagnostic notation)
 ])
 ~~~
 A TS may limit how often a new receipt can be issued, and respond with a 503 if a client requests new receipts too frequently.
-## Optional Endpoints
 
 The following HTTP endpoints are optional to implement.
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -593,7 +593,7 @@ Payload (in CBOR diagnostic notation)
     },
   },
   / payload     / null,
-  / signature   / h'02d227ed...ccd3774f'
+  / signature   / h'123227ed...ccd37123'
 ])
 ~~~
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -574,7 +574,7 @@ Payload (in CBOR diagnostic notation)
 / cose-sign1 / 18([
   / protected   / <<{
     / key / 4 : "0vx7agoebGc...9nndrQmbX",
-    / algorithm / 1 : -7,  # ES256
+    / algorithm / 1 : -35,  # ES384
     / vds           / 395 : 1, # RFC9162 SHA-256
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -539,7 +539,7 @@ Payload (in CBOR diagnostic notation)
   / protected   / <<{
     / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
     / algorithm / 1 : -7,  # ES256
-    / vds        / 395 : 1, # RFC9162 SHA-256
+    / vds       / 395 : 1, # RFC9162 SHA-256
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -530,6 +530,33 @@ Request:
 POST receipt-exchange HTTP/1.1
 Host: transparency.example
 Accept: application/cose
+
+Payload (in CBOR diagnostic notation)
+
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds           / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.example",
+      / subject / 2 : "https://green.example/cli@v1.2.3",
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
+])
 ~~~
 
 Response:

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -596,7 +596,7 @@ Payload (in CBOR diagnostic notation)
   / signature   / h'123227ed...ccd37123'
 ])
 ~~~
-
+A TS may limit how often a new receipt can be issued, and respond with a 503 if a client requests new receipts too frequently.
 ## Optional Endpoints
 
 The following HTTP endpoints are optional to implement.

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -520,6 +520,56 @@ application/concise-problem-details+cbor
 }
 ~~~
 
+### Exchange Receipt
+
+Authentication SHOULD be implemented for this endpoint.
+
+Request:
+
+~~~ http-message
+POST receipt-exchange HTTP/1.1
+Host: transparency.example
+Accept: application/cose
+~~~
+
+Response:
+
+#### Status 200 - OK
+
+If a new Receipt can be issued for the given submitted Receipt:
+
+~~~ http-message
+HTTP/1.1 200 Ok
+Content-Type: application/cose
+
+Payload (in CBOR diagnostic notation)
+
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds           / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.example",
+      / subject / 2 : "https://green.example/cli@v1.2.3",
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
+])
+~~~
+
 ## Optional Endpoints
 
 The following HTTP endpoints are optional to implement.

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -580,6 +580,7 @@ Payload (in CBOR diagnostic notation)
     / claims / 15 : {
       / issuer  / 1 : "https://blue.example",
       / subject / 2 : "https://green.example/cli@v1.2.3",
+      / iat / 6: 2443944944,
     },
   }>>,
   / unprotected / {


### PR DESCRIPTION
As discussed on the call, this endpoint enables a client to submit a receipt which they have, to receipt a new receipt from the TS.

This enables the TS to apply a simply policy to decide if a new receipt is required.