### PR TITLE
More consistent and representative receipt samples

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -682,29 +682,11 @@ Content-Type: application/cose
 
 Payload (in CBOR diagnostic notation)
 
-/ cose-sign1 / 18([
-  / protected   / <<{
-    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
-    / algorithm / 1 : -7,  # ES256
-    / vds       / 395 : 1, # RFC9162 SHA-256
-    / claims / 15 : {
-      / issuer  / 1 : "https://blue.notary.example",
-      / subject / 2 : "https://green.software.example/cli@v1.2.3",
-    },
-  }>>,
-  / unprotected / {
-    / proofs / 396 : {
-      / inclusion / -1 : [
-        <<[
-          / size / 9, / leaf / 8,
-          / inclusion path /
-          h'7558a95f...e02e35d6'
-        ]>>
-      ],
-    },
-  },
-  / payload     / null,
-  / signature   / h'02d227ed...ccd3774f'
+18([                            / COSE Sign1         /
+  h'a1013822',                  / Protected Header   /
+  {},                           / Unprotected Header /
+  null,                         / Detached Payload   /
+  h'269cd68f4211dffc...0dcb29c' / Signature          /
 ])
 ~~~
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -243,11 +243,29 @@ Content-Type: application/cose
 
 Payload (in CBOR diagnostic notation)
 
-18([                            / COSE Sign1         /
-  h'a1013822',                  / Protected Header   /
-  {},                           / Unprotected Header /
-  null,                         / Detached Payload   /
-  h'269cd68f4211dffc...0dcb29c' / Signature          /
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.notary.example",
+      / subject / 2 : "https://green.software.example/cli@v1.2.3",
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
 ])
 ~~~
 
@@ -322,11 +340,29 @@ Content-Type: application/cose
 
 Payload (in CBOR diagnostic notation)
 
-18([                            / COSE Sign1         /
-  h'a1013822',                  / Protected Header   /
-  {},                           / Unprotected Header /
-  null,                         / Detached Payload   /
-  h'269cd68f4211dffc...0dcb29c' / Signature          /
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.notary.example",
+      / subject / 2 : "https://green.software.example/cli@v1.2.3",
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
 ])
 ~~~
 
@@ -646,11 +682,29 @@ Content-Type: application/cose
 
 Payload (in CBOR diagnostic notation)
 
-18([                            / COSE Sign1         /
-  h'a1013822',                  / Protected Header   /
-  {},                           / Unprotected Header /
-  null,                         / Detached Payload   /
-  h'269cd68f4211dffc...0dcb29c' / Signature          /
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.notary.example",
+      / subject / 2 : "https://green.software.example/cli@v1.2.3",
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
 ])
 ~~~
 
@@ -692,11 +746,30 @@ Accept: application/cose
 Content-Type: application/cose
 Payload (in CBOR diagnostic notation)
 
-18([                            / COSE Sign1         /
-  h'a1013822',                  / Protected Header   /
-  {},                           / Unprotected Header /
-  null,                         / Detached Payload   /
-  h'269cd68f4211dffc...0dcb29c' / Signature          /
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.notary.example",
+      / subject / 2 : "https://green.software.example/cli@v1.2.3",
+      / iat     / 6 : 1750683311
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'02d227ed...ccd3774f'
 ])
 ~~~
 
@@ -712,11 +785,30 @@ Content-Type: application/cose
 
 Payload (in CBOR diagnostic notation)
 
-18([                            / COSE Sign1         /
-  h'a1013822',                  / Protected Header   /
-  {},                           / Unprotected Header /
-  null,                         / Detached Payload   /
-  h'269cd68f4211dffc...0dcb29c' / Signature          /
+/ cose-sign1 / 18([
+  / protected   / <<{
+    / key / 4 : "mxA4KiOkQFZ-dkLebSo3mLOEPR7rN8XtxkJe45xuyJk",
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
+    / claims / 15 : {
+      / issuer  / 1 : "https://blue.notary.example",
+      / subject / 2 : "https://green.software.example/cli@v1.2.3",
+      / iat     / 6 : 1750683573 # Post-refresh
+    },
+  }>>,
+  / unprotected / {
+    / proofs / 396 : {
+      / inclusion / -1 : [
+        <<[
+          / size / 9, / leaf / 8,
+          / inclusion path /
+          h'7558a95f...e02e35d6'
+        ]>>
+      ],
+    },
+  },
+  / payload     / null,
+  / signature   / h'48f67a8b...b474bb3a'
 ])
 ~~~
 

--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -736,7 +736,7 @@ Payload (in CBOR diagnostic notation)
     / claims / 15 : {
       / issuer  / 1 : "https://blue.notary.example",
       / subject / 2 : "https://green.software.example/cli@v1.2.3",
-      / iat     / 6 : 1750683311
+      / iat     / 6 : 1750683311 # Pre-refresh
     },
   }>>,
   / unprotected / {


### PR DESCRIPTION
Noticed while doing #73 that the sample receipts were inconsistent, and in the case of the refresh endpoint, less illustrative than they could be. This PR should address both (minor) points.