### PR TITLE
Remove duplicate Base64Url encoding reference

### DIFF
--- a/draft-ietf-scitt-scrapi.md
+++ b/draft-ietf-scitt-scrapi.md
@@ -334,8 +334,6 @@ If the `kid` values used by the service (`{kid_value}` in the request above) are
 
 {{Section 2 of RFC7515}} specifies Base64Url encoding as follows:
 
-{{RFC7515}} specifies Base64url encoding as follows:
-
 "Base64 encoding using the URL- and filename-safe character set
 defined in Section 5 of RFC 4648 {{RFC4648}}, with all trailing '='
 characters omitted and without the inclusion of any line breaks,


### PR DESCRIPTION
Removed duplicate mention of Base64Url encoding from the document.

Flagged by https://mailarchive.ietf.org/arch/msg/scitt/F8Elv2na-HZkQSYdS98N81NWfHE